### PR TITLE
chore(codex): refresh subagent model tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ chezmoi status
 - ロール本文の正本は `.chezmoitemplates/agent/roles/` に置く
 - Claude 用エージェントは `private_dot_claude/agents/*.md.tmpl` で frontmatter の差分だけを持つ
 - Codex 用エージェントは `dot_codex/agents/*.toml.tmpl` で TOML とモデル指定の差分だけを持つ
+- Codex 用モデル選択は `docs/codex-agent-model-selection.md` の松竹梅方針に従う
 - ロールの意味内容を変更する場合は、まず `.chezmoitemplates/agent/roles/` を更新する
 
 ## セキュリティ

--- a/docs/codex-agent-model-selection.md
+++ b/docs/codex-agent-model-selection.md
@@ -1,0 +1,37 @@
+# Codex サブエージェント モデル選択方針
+
+## 目的
+
+Codex のサブエージェントごとに、役割の重さに応じたモデルと reasoning effort を選ぶ。
+モデル名だけで性能階層を表現せず、松竹梅の役割分類と reasoning effort をセットで管理する。
+
+## 基本階層
+
+| 階層 | 用途 | モデル | reasoning effort |
+| --- | --- | --- | --- |
+| 松 | 設計判断、高リスクレビュー、構造改善 | `gpt-5.5` | `high` / `xhigh` |
+| 竹 | 実装、深い調査、ドキュメント再構成 | `gpt-5.4` | `medium` |
+| 梅 | 単一ファイル処理、lint、テスト、単一URL調査 | `gpt-5.4-mini` | `low` / `medium` |
+
+## ロール対応
+
+| agent | 階層 | model | reasoning effort | 理由 |
+| --- | --- | --- | --- | --- |
+| `architect` | 松 | `gpt-5.5` | `xhigh` | 設計判断の失敗が後続実装全体に波及するため |
+| `refactorer` | 松 | `gpt-5.5` | `xhigh` | 技術的負債の構造改善では誤った抽象化のコストが高いため |
+| `security-reviewer` | 松 | `gpt-5.5` | `high` | 脆弱性の見落としコストが高いため |
+| `implementer` | 竹 | `gpt-5.4` | `medium` | 仕様に沿った実装とテスト確認を安定して行うため |
+| `investigator` | 竹 | `gpt-5.4` | `medium` | 複数ファイル調査と根本原因分析を行うため |
+| `doc-writer` | 竹 | `gpt-5.4` | `medium` | ドキュメント構造の再整理を行うため |
+| `file-reader` | 梅 | `gpt-5.4-mini` | `low` | 単一ファイル読解に限定するため |
+| `lint-fixer` | 梅 | `gpt-5.4-mini` | `low` | 単一ファイルの機械的修正が中心のため |
+| `test-runner` | 梅 | `gpt-5.4-mini` | `low` | テスト実行と結果整理が中心のため |
+| `doc-checker` | 梅 | `gpt-5.4-mini` | `medium` | 実装とドキュメントの対応関係を読むため |
+| `web-researcher` | 梅 | `gpt-5.4-mini` | `medium` | 単一URLでも要約・信頼度判断が必要なため |
+
+## 運用ルール
+
+- `gpt-5.5` が使える環境では、松は `gpt-5.5` を標準にする。
+- `gpt-5.5` が使えない環境だけ、松を `gpt-5.4` と同じ reasoning effort に落とす。
+- `gpt-5.3-codex` は既定では使わない。明示的な検証・互換性確認・特殊事情がある場合のみ採用する。
+- reasoning effort は、親セッションからの継承で意図が曖昧になる agent では明示する。

--- a/dot_codex/agents/architect.toml.tmpl
+++ b/dot_codex/agents/architect.toml.tmpl
@@ -1,7 +1,7 @@
 name = "architect"
 description = "設計判断・API設計・モジュール構造の決定を担うagent。重要な設計選択が必要な場合に使う。実装は行わない。"
-model = "gpt-5.4"
-model_reasoning_effort = "high"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/architect.md" }}

--- a/dot_codex/agents/doc-checker.toml.tmpl
+++ b/dot_codex/agents/doc-checker.toml.tmpl
@@ -1,6 +1,7 @@
 name = "doc-checker"
 description = "実装とドキュメントの乖離を検知するagent。変更に追従漏れがないかを確認し、修正は行わない。"
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/doc-checker.md" }}

--- a/dot_codex/agents/file-reader.toml.tmpl
+++ b/dot_codex/agents/file-reader.toml.tmpl
@@ -1,6 +1,7 @@
 name = "file-reader"
 description = "単一ファイルを読み、調査目的に沿った要点を構造化して返すagent。1 agent = 1ファイルを原則とする。"
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
 sandbox_mode = "read-only"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/file-reader.md" }}

--- a/dot_codex/agents/implementer.toml.tmpl
+++ b/dot_codex/agents/implementer.toml.tmpl
@@ -1,6 +1,6 @@
 name = "implementer"
 description = "渡された仕様・計画をもとに、スコープ内で実装とテスト確認を完結させるagent。"
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/implementer.md" }}

--- a/dot_codex/agents/investigator.toml.tmpl
+++ b/dot_codex/agents/investigator.toml.tmpl
@@ -1,6 +1,6 @@
 name = "investigator"
 description = "複数ファイルにまたがる深い調査・因果分析を担うagent。根本原因と影響範囲を整理する。"
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/dot_codex/agents/lint-fixer.toml.tmpl
+++ b/dot_codex/agents/lint-fixer.toml.tmpl
@@ -1,6 +1,7 @@
 name = "lint-fixer"
 description = "単一ファイルの lint/静的解析エラーを修正するagent。1 agent = 1ファイルを原則とする。"
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/lint-fixer.md" }}
 """

--- a/dot_codex/agents/refactorer.toml.tmpl
+++ b/dot_codex/agents/refactorer.toml.tmpl
@@ -1,7 +1,7 @@
 name = "refactorer"
 description = "指定スコープの技術的負債を設計レベルで解消するagent。表面的ではなく根本的な構造改善を行う。"
-model = "gpt-5.3-codex"
-model_reasoning_effort = "high"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/refactorer.md" }}
 """

--- a/dot_codex/agents/security-reviewer.toml.tmpl
+++ b/dot_codex/agents/security-reviewer.toml.tmpl
@@ -1,6 +1,6 @@
 name = "security-reviewer"
 description = "実装・設計のセキュリティ分析を担うagent。脆弱性の見落としコストが高い変更で使う。"
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/dot_codex/agents/test-runner.toml.tmpl
+++ b/dot_codex/agents/test-runner.toml.tmpl
@@ -1,6 +1,7 @@
 name = "test-runner"
 description = "指定されたテスト対象のテストを実行し、結果を構造化して返すagent。修正は行わない。"
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/test-runner.md" }}
 """

--- a/dot_codex/agents/web-researcher.toml.tmpl
+++ b/dot_codex/agents/web-researcher.toml.tmpl
@@ -1,6 +1,7 @@
 name = "web-researcher"
 description = "単一URLの取得と構造化要約を担当するWeb調査agent。1 agent = 1 URL を原則とする。"
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """
 {{ include ".chezmoitemplates/agent/roles/web-researcher.md" }}


### PR DESCRIPTION
Reason: align Codex subagent defaults with the Matsutake-Ume model tier policy.

Impact: updates Codex agent model and reasoning effort templates, adds the model selection guide, and links it from README.

Breaking-Change: none